### PR TITLE
small improvement in label of value node

### DIFF
--- a/nodes/ccu-value.html
+++ b/nodes/ccu-value.html
@@ -34,7 +34,9 @@
             if (this.name) {
                 return this.name;
             }
+
             const dp = String(this.datapoint).replace(/PRESS_|_STATE|_MODE|ERROR_|OPERATING_|ACTUAL_|^STATE$|^LEVEL$/, '');
+
             return clipValueLength(String(this.channel).replace(/^[A-Za-z0-9-]+:\d /, ''), 17) + ((dp.length > 1 && dp.length < 10) ? ' ' + dp : '') || 'value';
         },
         labelStyle() {

--- a/nodes/ccu-value.html
+++ b/nodes/ccu-value.html
@@ -34,7 +34,7 @@
             if (this.name) {
                 return this.name;
             }
-            let dp = String(this.datapoint).replace(/PRESS_|_STATE|_MODE|ERROR_|OPERATING_|ACTUAL_|^STATE$/, '');
+            let dp = String(this.datapoint).replace(/PRESS_|_STATE|_MODE|ERROR_|OPERATING_|ACTUAL_|^STATE$|^LEVEL$/, '');
             return clipValueLength(String(this.channel).replace(/^[A-Za-z0-9-]+:\d /, ''), 17) + ((dp.length > 1 && dp.length < 10) ? ' ' + dp : '') || 'value';
         },
         labelStyle() {

--- a/nodes/ccu-value.html
+++ b/nodes/ccu-value.html
@@ -34,7 +34,7 @@
             if (this.name) {
                 return this.name;
             }
-            let dp = String(this.datapoint).replace(/PRESS_|_STATE|_MODE|ERROR_|OPERATING_|ACTUAL_|^STATE$|^LEVEL$/, '');
+            const dp = String(this.datapoint).replace(/PRESS_|_STATE|_MODE|ERROR_|OPERATING_|ACTUAL_|^STATE$|^LEVEL$/, '');
             return clipValueLength(String(this.channel).replace(/^[A-Za-z0-9-]+:\d /, ''), 17) + ((dp.length > 1 && dp.length < 10) ? ' ' + dp : '') || 'value';
         },
         labelStyle() {

--- a/nodes/ccu-value.html
+++ b/nodes/ccu-value.html
@@ -1,4 +1,8 @@
 <script type="text/javascript">
+    function clipValueLength(v, l) {
+        return (v.length > l) ? v.substring(0, (l - 3)) + '...' : v;
+    }
+
     RED.nodes.registerType('ccu-value', {
 
         category: 'ccu',
@@ -27,7 +31,11 @@
         paletteLabel: 'value',
         align: 'right',
         label() {
-            return this.name || String(this.channel).replace(/^[A-Za-z0-9-]+:\d /, '') || 'value';
+            if (this.name) {
+                return this.name;
+            }
+            let dp = String(this.datapoint).replace(/PRESS_|_STATE|_MODE|ERROR_|OPERATING_|ACTUAL_|^STATE$/, '');
+            return clipValueLength(String(this.channel).replace(/^[A-Za-z0-9-]+:\d /, ''), 17) + ((dp.length > 1 && dp.length < 10) ? ' ' + dp : '') || 'value';
         },
         labelStyle() {
             return this.name ? 'node_label_italic' : '';


### PR DESCRIPTION
Small improvement in the automatically displayed label of value node to limit length and add datapoint in some cases.
Often the value node will used for LEVEL or STATE datapoint. To thus it is sometimes important to know if the datapoint is an other. Example to have button to distinguish between long and short press datapoint.

Of course you can use the property name for that, but that's easier. ;)