### PR TITLE
Set in Get value empty sysvar

### DIFF
--- a/nodes/ccu-get-value.html
+++ b/nodes/ccu-get-value.html
@@ -110,7 +110,7 @@
                             }
                         });
                         $.getJSON('ccu?type=sysvar&config=' + nodeId, data => {
-                            $nodeInputSysvar.html('');
+                            $nodeInputSysvar.html('<option></option>');
                             if (data) {
                                 Object.keys(data).forEach(name => {
                                     $nodeInputSysvar.append('<option value="' + name + '"' + (name === node.sysvar ? ' selected' : '') + '>' + name + '</option>');


### PR DESCRIPTION
Actually is not possible to clean the sysvar if it was set in the config, but if you send sysvar from msg input this is necessary.